### PR TITLE
If expression parser

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -88,6 +88,12 @@ type (
 		Token      token.Token
 		Statements []Statement
 	}
+
+	// ExpressionStatement represent expression in a statement
+	ExpressionStatement struct {
+		Token token.Token
+		Expression Expression 
+	}
 )
 
 func (v *VarStatement) statementNode()   {}
@@ -151,6 +157,25 @@ func (bs *BlockStatement) String() string {
 		out.WriteString(s.String())
 	}
 	return out.String()
+}
+
+func (e *ExpressionStatement) statementNode()       {}
+func (e *ExpressionStatement) TokenLiteral() string { return e.Token.Literal }
+func (e *ExpressionStatement) Start() token.Pos     { return e.Token.Start }
+func (e *ExpressionStatement) End() token.Pos {
+	end := e.Token.End
+
+	if e.Expression != nil {
+		end = e.Expression.End()
+	}
+
+	return end
+}
+func (e *ExpressionStatement) String() string {
+	if e.Expression != nil {
+		return e.String()
+	}
+	return e.Token.String()
 }
 
 // expression


### PR DESCRIPTION
**What this PR does?**
- This PR add the parser to parse IF and else expression.
- I have also simplify the testing, by creating testing helper method.
- I have added the parser to parse expressionStatement


**Why this PR is important?**
This way the parser can start parsing IF and else expression. 

It is important to restructure the tests at this point of the project, because in the future there will be more tests added and even at this point the tests is relatively messy and we need to create some helper functions to help automate some repetitive work in testing. 

For instance, in `checkStatement ` I can just pass in the value to be tested into `stmt`, and the expecting type I want `stmt` to be in `expected`.
```
func checkStatement[expected any](t *testing.T, stmt ast.Statement) expected {
	if stmt == nil {
		t.Fatal("statement is nil")
	}
	v, ok := stmt.(expected)
	if !ok {
		t.Fatalf("statement wrong type: got=%T expected=%T", stmt, v)
	}
	return v
}
```

That way I can just do this:
```
exprSt := checkStatement[*ast.ExpressionStatement](t, main.Statements[0])
```

instead of
```
		returnStmt, ok := stmt.(*ast.ExpressionStatement)
		if !ok {
			t.Errorf("stmt not *ast.ExpressionStatement. got=%T", stmt)
		}
```

This is justify as we need to assert alot of the variable type.
