### PR TITLE
add support to parse binary expression

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -173,7 +173,7 @@ func (e *ExpressionStatement) End() token.Pos {
 }
 func (e *ExpressionStatement) String() string {
 	if e.Expression != nil {
-		return e.String()
+		return e.Expression.String()
 	}
 	return e.Token.String()
 }
@@ -200,6 +200,13 @@ type (
 		Condition Expression
 		Body      *BlockStatement
 		Else      *BlockStatement
+	}
+
+	BinaryExpression struct {
+		Token token.Token
+		Left Expression
+		Operator string
+		Right Expression
 	}
 )
 
@@ -259,4 +266,33 @@ func (i *IFExpression) String() string {
 	}
 	st.WriteString(";")
 	return st.String()
+}
+
+
+func (b *BinaryExpression) expressionNode()  {}
+func (b *BinaryExpression) Start() token.Pos { 
+	if b.Left != nil {
+		return b.Left.Start()
+	}
+	return b.Token.Start
+}
+func (b *BinaryExpression) End() token.Pos   { 
+	if b.Right != nil {
+		return b.Right.End()
+	}
+	return b.Token.End
+}
+func (b *BinaryExpression) String() string   {
+	var s strings.Builder
+	s.WriteString("(")
+	if b.Left != nil {
+		s.WriteString(b.Left.String())
+	}
+
+	s.WriteString(") " + b.Operator + "( ")
+	if b.Right != nil {
+		s.WriteString(b.Right.String())
+	}
+	s.WriteString(") ")
+	return s.String()
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -69,6 +69,12 @@ func (l *Lexer) Lex() (token.Token, error) {
 	case '}':
 		pos := l.currentPos()
 		tok = newToken(token.RBRACE, "}", pos, pos)
+	case '>':
+		pos := l.currentPos()
+		tok = newToken(token.GTR, ">", pos, pos)
+	case '<':
+		pos := l.currentPos()
+		tok = newToken(token.LSS, "<", pos, pos)
 	case '!':
 		start := l.currentPos()
 		if l.peekByte() == '=' {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -70,6 +70,17 @@ func new(filename string, l *lexer.Lexer) *parser {
 		token.IF: p.parseIFExpression, 
 	}
 
+	p.binaryExpressionFunc = map[token.TokenType]binaryExpressionFunc{
+		token.ADD: p.parseBinaryExpression,
+		token.MINUS: p.parseBinaryExpression,
+		token.MUL: p.parseBinaryExpression,
+		token.DIVIDE: p.parseBinaryExpression,
+		token.LSS: p.parseBinaryExpression,
+		token.GTR: p.parseBinaryExpression,
+		token.NOT_EQUAL: p.parseBinaryExpression,
+		token.EQUAL: p.parseBinaryExpression,
+	}
+
 	return p
 }
 
@@ -173,6 +184,19 @@ func (p *parser) parseExpression(precedence int) ast.Expression {
 	}
 
 	return result
+}
+
+func (p *parser) parseBinaryExpression(left ast.Expression) ast.Expression {
+	expr := &ast.BinaryExpression{
+		Token: p.currentToken,
+		Left: left,
+		Operator: p.currentToken.Literal,
+	}
+
+	pred := p.pred()
+	p.next()
+	expr.Right = p.parseExpression(pred)
+	return expr
 }
 
 func (p *parser) parseIFExpression() ast.Expression {


### PR DESCRIPTION
**What this PR does?**
- This PR add support for to parse binary expression
- Add tests for various case for binary operations
- Add tests when parser parse a expressionStatement
- Add lexer to lex token such as '>' and '<'
- Fixed an error for ast.ExpressionStatement.String()


**Why this PR is important?**
This allow the parser to parse binary expression. Most importantly, we have added different tests cases for our parser to improve the confident of the parser jobs.


