### PR TITLE
add support for string type

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -268,6 +268,11 @@ type (
 		Function  Expression
 		Arguments []Expression
 	}
+
+	String struct {
+		Token token.Token
+		Value string
+	}
 )
 
 func (n *Number) expressionNode()  {}
@@ -436,3 +441,8 @@ func (c *CallExpression) String() string {
 
 	return out.String()
 }
+
+func (n *String) expressionNode()  {}
+func (n *String) Start() token.Pos { return n.Token.Start }
+func (n *String) End() token.Pos   { return n.Token.End }
+func (n *String) String() string   { return n.Token.Literal }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -106,6 +106,8 @@ func eval(node ast.Node, env *object.Environment) object.Object {
 			return val
 		}
 		return &object.ReturnValue{Value: val}
+	case *ast.String:
+		return &object.String{Value: node.Value}
 	}
 	return nil
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -34,12 +34,13 @@ func TestEval(t *testing.T) {
 func TestVarStatement(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected int
+		expected any
 	}{
 		{"var a = 5; a;", 5},
 		{"var a = 5 * 7;", 35},
 		{"var a = 5; var b = a; b;", 5},
 		{"var a = 5; var b = a; var c = a + b + 5; c;", 15},
+		{`var hello = "Hello world"; hello;`, "Hello world"},
 	}
 
 	for _, tt := range tests {
@@ -356,6 +357,8 @@ func testValue(t *testing.T, obj object.Object, expectedValue any) {
 		if obj != v {
 			t.Errorf("expecting null got=%v", v)
 		}
+	case string:
+		testString(t, obj, v)
 	default:
 		t.Errorf("invalid type for expected value")
 	}
@@ -366,6 +369,14 @@ func testBool(t *testing.T, obj object.Object, v bool) {
 
 	if b.Value != v {
 		t.Errorf("wrong boolean value: got=%v expected=%v", b.Value, v)
+	}
+}
+
+func testString(t *testing.T, obj object.Object, v string) {
+	s := checkObject[*object.String](t, obj)
+
+	if s.Value != v {
+		t.Errorf("wrong string value: got=%v expected=%v", s.Value, v)
 	}
 }
 

--- a/lexer/lexer_test_file.js
+++ b/lexer/lexer_test_file.js
@@ -10,3 +10,5 @@ var foo = function(a, func) {
 foo(4, add);
 
 var total = num * 90;
+
+"hello";

--- a/object/object.go
+++ b/object/object.go
@@ -18,6 +18,7 @@ const (
 	RETURN_VALUE_OBJECT ObjectType = "RETURN_VALUE"
 	ERROR_OBJECT        ObjectType = "ERROR"
 	FUNCTION_OBJECT     ObjectType = "FUNCTION"
+	STRING_OBJECT       ObjectType = "STRING"
 )
 
 // Object is used in the evaluator to represent value in when evaluating the AST of JSGO.
@@ -80,6 +81,13 @@ func (f *Function) String() string {
 	return out.String()
 }
 func (f *Function) Type() ObjectType { return FUNCTION_OBJECT }
+
+type String struct {
+	Value string
+}
+
+func (s *String) String() string   { return s.Value }
+func (s *String) Type() ObjectType { return RETURN_VALUE_OBJECT }
 
 // ReturnValue represent the value that is being returned
 type ReturnValue struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -95,6 +95,7 @@ func new(filename string, l *lexer.Lexer) *parser {
 		token.BANG:     p.parseUnaryExpression,
 		token.FUNCTION: p.parseFunctionDeclaration,
 		token.LPAREN:   p.parseGroupedExpression,
+		token.STRING:   p.parseStringExpression,
 	}
 
 	p.binaryExpressionFunc = map[token.TokenType]binaryExpressionFunc{
@@ -484,6 +485,11 @@ func (p *parser) parseFloat() ast.Expression {
 
 func (p *parser) parseBoolean() ast.Expression {
 	return &ast.Boolean{Token: p.currentToken, Value: p.expect(token.TRUE)}
+}
+
+func (p *parser) parseStringExpression() ast.Expression {
+	p.check(token.STRING)
+	return &ast.String{Token: p.currentToken, Value: p.currentToken.Literal}
 }
 
 func (p *parser) peekPred() int {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -55,6 +55,7 @@ func TestVar(t *testing.T) {
 		{"var yellow = true;", "yellow", true},
 		{"var numApp = 10.1;", "numApp", 10.1},
 		{"var numApp = apple;", "numApp", "apple"},
+		{"var apple = \"Hello world\";", "apple", "Hello world"},
 	}
 
 	for _, tt := range tests {
@@ -517,6 +518,9 @@ func testValueExpression(t *testing.T, exp ast.Expression, expected any) bool {
 	case float64:
 		return testFloatValue(t, exp, v)
 	case string:
+		if str, ok := exp.(*ast.String); ok {
+			return testString(t, str, v)
+		}
 		return testIdentifier(t, exp, v)
 	case bool:
 		return testBoolean(t, exp, v)
@@ -570,6 +574,20 @@ func testIdentifier(t *testing.T, exp ast.Expression, i string) bool {
 
 	if ident.String() != i {
 		t.Errorf("*ast.Identifier wrong Literal: got=%s, expected=%s", ident.String(), i)
+		return false
+	}
+	return true
+}
+
+func testString(t *testing.T, exp ast.Expression, i string) bool {
+	str, ok := exp.(*ast.String)
+	if !ok {
+		t.Errorf("node not *ast.String: got=%T", exp)
+		return false
+	}
+
+	if str.Value != i {
+		t.Errorf("*ast.String wrong string: got=%s, expected=%s", str.Value, i)
 		return false
 	}
 	return true

--- a/performance/2024-08-04_18-40-32.txt
+++ b/performance/2024-08-04_18-40-32.txt
@@ -1,0 +1,116 @@
+?   	github.com/jf550-kent/jsgo	[no test files]
+PASS
+ok  	github.com/jf550-kent/jsgo/ast	0.002s
+?   	github.com/jf550-kent/jsgo/benchmark	[no test files]
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/evaluator
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkExample-4   	 1410450	       869.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1371835	       859.7 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1397948	       863.6 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1390899	       920.2 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1386721	       865.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1392194	       864.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1360335	       867.3 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1383500	       863.1 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1394316	       869.8 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1379493	       867.1 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1385312	       873.2 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1369682	       869.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1376802	       866.8 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1384286	       869.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1378576	       858.5 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1357249	       864.4 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1387782	       867.4 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1381051	       861.9 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1375983	       871.5 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1358454	       870.9 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1374644	       867.1 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1380169	       869.9 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1383174	       867.8 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1391676	       866.3 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1386512	       864.6 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1377066	       872.5 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1388695	       866.0 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1383843	       865.2 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1391547	       860.1 ns/op	     912 B/op	      14 allocs/op
+BenchmarkExample-4   	 1383273	       863.9 ns/op	     912 B/op	      14 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/evaluator	62.424s
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/lexer
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkLex-4   	18393121	        65.05 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18296888	        65.02 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18060674	        64.99 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18033466	        64.98 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18112676	        64.90 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18031574	        64.85 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18122270	        65.02 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17977203	        65.05 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17931810	        64.86 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17815956	        64.95 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17840648	        65.10 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17911207	        65.01 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18009547	        64.88 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17984514	        65.13 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17903329	        64.88 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18000772	        65.12 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18034579	        64.99 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18149722	        69.48 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17932424	        64.81 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18059590	        64.97 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18033734	        64.86 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17938396	        65.01 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17971419	        64.80 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18114144	        64.86 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18002319	        64.99 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18022060	        64.91 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17481002	        64.93 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17881712	        65.09 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	17945361	        64.99 ns/op	       8 B/op	       1 allocs/op
+BenchmarkLex-4   	18093175	        64.89 ns/op	       8 B/op	       1 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/lexer	37.252s
+?   	github.com/jf550-kent/jsgo/object	[no test files]
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/parser
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkExample-4   	  231175	      5180 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  227932	      5088 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  230298	      5076 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  228634	      5089 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  224835	      5098 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  219231	      5086 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  228858	      5094 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  224592	      5110 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  229534	      5096 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  224247	      5095 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  217134	      5090 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  231240	      5098 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  228632	      5111 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  227811	      5085 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  225110	      5105 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  227019	      5091 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  225397	      5082 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  229890	      5100 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  228253	      5348 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  227460	      5131 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  223558	      5095 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  231778	      5097 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  229116	      5104 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  226833	      5092 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  228836	      5113 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  229875	      5105 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  221691	      5110 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  224822	      5125 ns/op	    3809 B/op	      81 allocs/op
+BenchmarkExample-4   	  225902	      5109 ns/op	    3810 B/op	      81 allocs/op
+BenchmarkExample-4   	  219928	      5114 ns/op	    3809 B/op	      81 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/parser	36.409s
+?   	github.com/jf550-kent/jsgo/run	[no test files]
+PASS
+ok  	github.com/jf550-kent/jsgo/token	0.002s


### PR DESCRIPTION
**What this PR does?**
- https://github.com/jf550-kent/jsgo/issues/19 

Yes we finally have string for JSGO.


**Why this PR is important?**
JSGO has support for all string type. The compiler can compile \u and \U unicode characters:

It passed all the tests for: 

