### PR TITLE
TES

### DIFF
--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -126,7 +126,7 @@ var definitions = map[Opcode]*Definition{
 	OpClosure:        {"OpClosure", []int{2, 1}, 3, 2},
 	OpGetFree:        {"OpGetFree", []int{1}, 1, 1},
 	OpCurrentClosure: {"OpCurrentClosure", []int{}, 0, 0},
-	OpIndexAssign: {"OpIndexAssign", []int{}, 0, 0},
+	OpIndexAssign:    {"OpIndexAssign", []int{}, 0, 0},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -83,6 +83,7 @@ const (
 	OpClosure
 	OpGetFree
 	OpCurrentClosure
+	OpIndexAssign
 )
 
 type Definition struct {
@@ -125,6 +126,7 @@ var definitions = map[Opcode]*Definition{
 	OpClosure:        {"OpClosure", []int{2, 1}, 3, 2},
 	OpGetFree:        {"OpGetFree", []int{1}, 1, 1},
 	OpCurrentClosure: {"OpCurrentClosure", []int{}, 0, 0},
+	OpIndexAssign: {"OpIndexAssign", []int{}, 0, 0},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -66,6 +66,9 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err := c.Compile(node.Expression); err != nil {
 			return err
 		}
+		if _, ok := node.Expression.(*ast.BracketDeclaration); ok {
+			break
+		}
 		c.emit(bytecode.OpPop)
 
 	case *ast.BlockStatement:
@@ -234,8 +237,8 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(bytecode.OpIndexAssign)
-		aoksl := c.scopesStack[c.scopeIndex].instructions.String(); 
-		print(aoksl) 
+
+
 	case *ast.Dictionary:
 		keys := []ast.Expression{}
 		for k := range node.Object {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -222,7 +222,20 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 		c.emit(bytecode.OpArray, len(node.Body))
-
+	
+	case *ast.BracketDeclaration:
+		if err := c.Compile(node.Identifier); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Key); err != nil {
+			return err
+		}
+		if err := c.Compile(node.Value); err != nil {
+			return err
+		}
+		c.emit(bytecode.OpIndexAssign)
+		aoksl := c.scopesStack[c.scopeIndex].instructions.String(); 
+		print(aoksl) 
 	case *ast.Dictionary:
 		keys := []ast.Expression{}
 		for k := range node.Object {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -225,7 +225,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 		c.emit(bytecode.OpArray, len(node.Body))
-	
+
 	case *ast.BracketDeclaration:
 		if err := c.Compile(node.Identifier); err != nil {
 			return err
@@ -237,7 +237,6 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(bytecode.OpIndexAssign)
-
 
 	case *ast.Dictionary:
 		keys := []ast.Expression{}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -363,7 +363,7 @@ func TestBracket(t *testing.T) {
 		// 	},
 		// },
 		{
-			input: `var dic = { "next": 10}; dic["current"] = 20`,
+			input:             `var dic = { "next": 10}; dic["current"] = 20`,
 			expectedConstants: []any{"next", 10, "current", 20},
 			expectedInstructions: []bytecode.Instructions{
 				bytecode.Make(bytecode.OpConstant, 0),

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -349,23 +349,33 @@ func TestVarStatements(t *testing.T) {
 
 func TestBracket(t *testing.T) {
 	tests := []compilerTestCase{
+		// {
+		// 	input:    "var arr = [10]; arr[0] = 90",
+		// 	expectedConstants: []any{10, 0, 90},
+		// 	expectedInstructions: []bytecode.Instructions{
+		// 		bytecode.Make(bytecode.OpConstant, 0),
+		// 		bytecode.Make(bytecode.OpArray, 1),
+		// 		bytecode.Make(bytecode.OpSetGlobal, 0),
+		// 		bytecode.Make(bytecode.OpGetGlobal, 0),
+		// 		bytecode.Make(bytecode.OpConstant, 1),
+		// 		bytecode.Make(bytecode.OpConstant, 2),
+		// 		bytecode.Make(bytecode.OpIndexAssign),
+		// 	},
+		// },
 		{
-			input:    "var arr = [10]; arr[0] = 90",
-			expectedConstants: []any{10, 0, 90},
+			input: `var dic = { "next": 10}; dic["current"] = 20`,
+			expectedConstants: []any{"next", 10, "current", 20},
 			expectedInstructions: []bytecode.Instructions{
 				bytecode.Make(bytecode.OpConstant, 0),
-				bytecode.Make(bytecode.OpArray, 1),
+				bytecode.Make(bytecode.OpConstant, 1),
+				bytecode.Make(bytecode.OpDic, 2),
 				bytecode.Make(bytecode.OpSetGlobal, 0),
 				bytecode.Make(bytecode.OpGetGlobal, 0),
-				bytecode.Make(bytecode.OpConstant, 1),
 				bytecode.Make(bytecode.OpConstant, 2),
+				bytecode.Make(bytecode.OpConstant, 3),
 				bytecode.Make(bytecode.OpIndexAssign),
-				bytecode.Make(bytecode.OpPop),
 			},
 		},
-		{
-			input: `var dic = { "next": 10};
-		}
 	}
 
 	testCompilerTests(t, tests)
@@ -894,6 +904,8 @@ func testCompilerTests(t *testing.T, tests []compilerTestCase) {
 		}
 
 		bytecode := compiler.ByteCode()
+		a := bytecode.Instructions.String()
+		print(a)
 
 		testInstructions(t, tt.expectedInstructions, bytecode.Instructions)
 		testConstants(t, tt.expectedConstants, bytecode.Constants)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -347,6 +347,29 @@ func TestVarStatements(t *testing.T) {
 	testCompilerTests(t, tests)
 }
 
+func TestBracket(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:    "var arr = [10]; arr[0] = 90",
+			expectedConstants: []any{10, 0, 90},
+			expectedInstructions: []bytecode.Instructions{
+				bytecode.Make(bytecode.OpConstant, 0),
+				bytecode.Make(bytecode.OpArray, 1),
+				bytecode.Make(bytecode.OpSetGlobal, 0),
+				bytecode.Make(bytecode.OpGetGlobal, 0),
+				bytecode.Make(bytecode.OpConstant, 1),
+				bytecode.Make(bytecode.OpConstant, 2),
+				bytecode.Make(bytecode.OpIndexAssign),
+				bytecode.Make(bytecode.OpPop),
+			},
+		},
+		{
+			input: `var dic = { "next": 10};
+		}
+	}
+
+	testCompilerTests(t, tests)
+}
 func TestStringExpression(t *testing.T) {
 	tests := []compilerTestCase{
 		{

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -84,6 +84,7 @@ func eval(node ast.Node, env *object.Environment) object.Object {
 		params := node.Parameters
 		body := node.Body
 		return &object.Function{Parameters: params, Body: body, Env: env}
+		
 	case *ast.CallExpression:
 		args := evalExpressions(node.Arguments, env)
 		if len(args) == 1 && isError(args[0]) {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -84,7 +84,7 @@ func eval(node ast.Node, env *object.Environment) object.Object {
 		params := node.Parameters
 		body := node.Body
 		return &object.Function{Parameters: params, Body: body, Env: env}
-		
+
 	case *ast.CallExpression:
 		args := evalExpressions(node.Arguments, env)
 		if len(args) == 1 && isError(args[0]) {

--- a/performance/2024-08-15_14-33-19.txt
+++ b/performance/2024-08-15_14-33-19.txt
@@ -1,0 +1,45 @@
+?   	github.com/jf550-kent/jsgo	[no test files]
+PASS
+ok  	github.com/jf550-kent/jsgo/ast	0.003s
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/benchmark
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkList-4         	     100	  11850765 ns/op	 3377365 B/op	   75797 allocs/op
+BenchmarkTower-4        	      40	  28651471 ns/op	15799394 B/op	  282906 allocs/op
+BenchmarkMandelbrot-4   	       1	34135407614 ns/op	3261057352 B/op	407626931 allocs/op
+BenchmarkPermute-4      	      75	  15484236 ns/op	 8315221 B/op	  145896 allocs/op
+BenchmarkSieve-4        	     145	   8214105 ns/op	 1201696 B/op	  108937 allocs/op
+BenchmarkQueens-4       	      93	  11583150 ns/op	 5929935 B/op	  123239 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/benchmark	41.416s
+PASS
+ok  	github.com/jf550-kent/jsgo/bytecode	0.002s
+PASS
+ok  	github.com/jf550-kent/jsgo/compiler	0.002s
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/evaluator
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkExample-4   	       1	33247364538 ns/op	3295575032 B/op	408361510 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/evaluator	33.250s
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/lexer
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkLex-4   	18559951	        64.25 ns/op	       8 B/op	       1 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/lexer	1.262s
+?   	github.com/jf550-kent/jsgo/object	[no test files]
+goos: linux
+goarch: amd64
+pkg: github.com/jf550-kent/jsgo/parser
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkExample-4   	    6442	    174870 ns/op	  107112 B/op	    2119 allocs/op
+PASS
+ok  	github.com/jf550-kent/jsgo/parser	1.149s
+PASS
+ok  	github.com/jf550-kent/jsgo/token	0.002s
+PASS
+ok  	github.com/jf550-kent/jsgo/vm	0.002s

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -141,6 +141,25 @@ func (vm *VM) Run() error {
 			if err := vm.push(array); err != nil {
 				return err
 			}
+		case bytecode.OpIndexAssign:
+			ident := vm.stack[vm.stackPointer-3]
+			index, ok := vm.stack[vm.stackPointer-2].(*object.Number)
+			if !ok {
+				return fmt.Errorf("wrong type for array index")
+			}
+			expr := vm.stack[vm.stackPointer-1]
+
+			switch val := ident.(type) {
+			case *object.Array:
+				if int(index.Value) >= len(val.Body) {
+					newArr := make([]object.Object, int(index.Value)+1)
+					copy(newArr, val.Body)
+					val.Body = newArr
+				}
+				val.Body[index.Value] = expr
+			default:
+				return fmt.Errorf("cannot index with type=%v", ident)
+			}
 		case bytecode.OpDic:
 			size := int(bytecode.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -177,7 +177,7 @@ func (vm *VM) Run() error {
 			default:
 				return fmt.Errorf("cannot index with type=%v", ident)
 			}
-			
+
 		case bytecode.OpDic:
 			size := int(bytecode.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -236,6 +236,17 @@ func TestRecursiveFibonacci(t *testing.T) {
 	testVmTests(t, tests)
 }
 
+func TestBracket(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input:    "var arr = [10]; arr[1] = 90; arr;",
+			expected: []int{10, 90},
+		},
+	}
+	
+	testVmTests(t, tests)
+}
+
 func testVmTests(t *testing.T, tests []vmTestCase) {
 	t.Helper()
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -238,12 +238,16 @@ func TestRecursiveFibonacci(t *testing.T) {
 
 func TestBracket(t *testing.T) {
 	tests := []vmTestCase{
+		{input: "var arr = [10]; arr[1] = 90; arr;", expected: []int{10, 90}},
 		{
-			input:    "var arr = [10]; arr[1] = 90; arr;",
-			expected: []int{10, 90},
+			input: `var dic = { "next": 10}; dic["current"] = 20 dic;`,
+			expected: map[object.Hash]int64{
+				(&object.String{Value: "next"}).Hash():    10,
+				(&object.String{Value: "current"}).Hash(): 20,
+			},
 		},
 	}
-	
+
 	testVmTests(t, tests)
 }
 


### PR DESCRIPTION
**What this PR does?**
- Add bytecode compiler for bracket assignment

**Why this PR is important?**
To allow the bytecode interpreter for assignment
```
var arr = []
arr[0] = 10

var dic = {}
dic["next"] = 10
``` 


